### PR TITLE
Handle open redirect by only allowing redirect to permitted hosts

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from django.contrib import auth
 from django.shortcuts import redirect, render
+from django.utils.encoding import iri_to_uri
 from django.utils.http import url_has_allowed_host_and_scheme
 from django.views.decorators.csrf import csrf_exempt
 
@@ -14,6 +15,7 @@ def base_css(request):
 @csrf_exempt
 def login(request):
     next = request.GET.get('next') or request.POST.get('next') or '/'
+    next = iri_to_uri(next)
     if not url_has_allowed_host_and_scheme(next, settings.ALLOWED_HOSTS):
         next = '/'
 

--- a/core/views.py
+++ b/core/views.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from django.contrib import auth
 from django.shortcuts import redirect, render
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.views.decorators.csrf import csrf_exempt
 
 
@@ -13,6 +14,8 @@ def base_css(request):
 @csrf_exempt
 def login(request):
     next = request.GET.get('next') or request.POST.get('next') or '/'
+    if not url_has_allowed_host_and_scheme(next, settings.ALLOWED_HOSTS):
+        next = '/'
 
     if request.user.is_authenticated:
         return redirect(next)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       DATABASE_URL: postgres://aptible:password@pg:5432/db
       DEBUG: True
       DEFAULT_FROM_EMAIL: ${DEFAULT_FROM_EMAIL:-test@example.com}
+      HOST: localhost
       SECRET_KEY: SECRET_KEY
 
       # Also be evil?

--- a/teamspace/settings.py
+++ b/teamspace/settings.py
@@ -12,7 +12,7 @@ SECRET_KEY = 'SECRET_KEY'
 # Don't enable this in production!
 DEBUG = 'DEBUG' in os.environ.keys()
 
-ALLOWED_HOSTS = ['*']
+ALLOWED_HOSTS = [os.environ['HOST']]
 CSRF_TRUSTED_ORIGINS = ['https://*.on-aptible.com', 'http://localhost:8000']
 
 # Application definition


### PR DESCRIPTION
The `redirect` method doesn't care about where it is redirecting to. When combined with a view that redirects based on parameter passed in, it opens up a dangerous situation where the view has an open redirect to anywhere.

This PR removes the open redirect on login by validating that the redirect matches a known list (in this case, `ALLOWED_HOSTS`).